### PR TITLE
Strip MD5 prefixes from menu listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ ninox generate-menu-tree --bucket my-bucket --cdn-host https://cdn.example.com
 ```
 
 The command creates `content/hal_menus/...` directories with daily `index.md` files linking to the PDFs via the provided CDN host.
+Any leading 32-character MD5 hashes in the filenames are stripped from the link display names.

--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -26,6 +27,13 @@ SHIPS = {
     "we": "Westerdam",
     "zu": "Zuiderdam",
 }
+
+MD5_PREFIX = re.compile(r"^[0-9a-f]{32}[-_]")
+
+
+def strip_md5_prefix(name: str) -> str:
+    """Remove an MD5 prefix from ``name`` if present."""
+    return MD5_PREFIX.sub("", name)
 
 
 def slug(name: str) -> str:
@@ -72,7 +80,7 @@ def write_day_page(
     lines = ["---", f"title: {date:%Y-%m-%d}", "hiddenInHomeList: true", "---", ""]
     for key in keys:
         url = f"{cdn_host}/{key}"
-        name = Path(key).name
+        name = strip_md5_prefix(Path(key).name)
         lines.append(f"- [{name}]({url})")
     (day_dir / "index.md").write_text("\n".join(lines))
 


### PR DESCRIPTION
## Summary
- strip MD5 prefixes from filenames when generating menu links
- test prefix stripping
- update documentation on the new behaviour

## Testing
- `uv run ruff check ninox/s3_hugo.py tests/test_s3_hugo.py`
- `uv run mypy ninox/s3_hugo.py tests/test_s3_hugo.py` *(fails: cannot find stub for boto3, pytest)*
- `uv run pytest -q`
- `pre-commit run --files ninox/s3_hugo.py tests/test_s3_hugo.py README.md`