### PR TITLE
Generate yearly menu pages

### DIFF
--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -80,7 +80,7 @@ def write_year_page(
 
     for month in sorted(month_map):
         month_name = dt.date(year, month, 1).strftime("%B")
-        lines.extend((f"<details><summary>{month_name}</summary>", ""))
+        lines.extend((f"{{{{< details title="{month_name}" >}}}}", ""))
         for date in sorted(month_map[month]):
             lines.append(f"### {date:%Y-%m-%d}")
             for key in sorted(month_map[month][date]):
@@ -88,7 +88,7 @@ def write_year_page(
                 name = strip_md5_prefix(Path(key).name)
                 lines.append(f"- [{name}]({url})")
             lines.append("")
-        lines.extend(("</details>", ""))
+        lines.extend(("{{< /details >}}", ""))
 
     (year_dir / "index.md").write_text("\n".join(lines))
 

--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -103,9 +103,6 @@ def create_tree(bucket: str, prefix: str, output: Path, cdn_host: str) -> None:
         ship_name = SHIPS[code]
         ship_dir = root / slug(ship_name)
         ensure_section(ship_dir, ship_name)
-        for year in {d.year for c, d in groups if c == code}:
-            year_dir = ship_dir / f"{year}"
-            ensure_section(year_dir, str(year))
 
     year_groups: dict[tuple[str, int], dict[dt.date, list[str]]] = defaultdict(
         lambda: defaultdict(list)

--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -80,7 +80,7 @@ def write_year_page(
 
     for month in sorted(month_map):
         month_name = dt.date(year, month, 1).strftime("%B")
-        lines.extend((f"{{{{< details title=\"{month_name}\" >}}}}", ""))
+        lines.extend((f'{{{{< details title="{month_name}" >}}}}', ""))
         for date in sorted(month_map[month]):
             lines.append(f"### {date:%Y-%m-%d}")
             for key in sorted(month_map[month][date]):

--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -4,13 +4,9 @@ import datetime as dt
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import boto3
 import click
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 MIN_PARTS = 4
 
@@ -68,21 +64,33 @@ def group_objects(bucket: str, prefix: str) -> dict[tuple[str, dt.date], list[st
     return groups
 
 
-def write_day_page(
-    base: Path, ship_code: str, date: dt.date, keys: Iterable[str], cdn_host: str
+def write_year_page(
+    base: Path, ship_code: str, year: int, days: dict[dt.date, list[str]], cdn_host: str
 ) -> None:
-    """Write an ``index.md`` listing ``keys`` for a single day."""
+    """Write an ``index.md`` listing all menus for ``year`` grouped by month."""
     ship_slug = slug(SHIPS[ship_code])
-    day_dir = (
-        base / "hal_menus" / ship_slug / f"{date:%Y}" / f"{date:%m}" / f"{date:%d}"
-    )
-    day_dir.mkdir(parents=True, exist_ok=True)
-    lines = ["---", f"title: {date:%Y-%m-%d}", "hiddenInHomeList: true", "---", ""]
-    for key in keys:
-        url = f"{cdn_host}/{key}"
-        name = strip_md5_prefix(Path(key).name)
-        lines.append(f"- [{name}]({url})")
-    (day_dir / "index.md").write_text("\n".join(lines))
+    year_dir = base / "hal_menus" / ship_slug / f"{year}"
+    year_dir.mkdir(parents=True, exist_ok=True)
+
+    lines = ["---", f"title: {year}", "hiddenInHomeList: true", "---", ""]
+
+    month_map: dict[int, dict[dt.date, list[str]]] = defaultdict(dict)
+    for date, keys in days.items():
+        month_map[date.month][date] = keys
+
+    for month in sorted(month_map):
+        month_name = dt.date(year, month, 1).strftime("%B")
+        lines.extend((f"<details><summary>{month_name}</summary>", ""))
+        for date in sorted(month_map[month]):
+            lines.append(f"### {date:%Y-%m-%d}")
+            for key in sorted(month_map[month][date]):
+                url = f"{cdn_host}/{key}"
+                name = strip_md5_prefix(Path(key).name)
+                lines.append(f"- [{name}]({url})")
+            lines.append("")
+        lines.extend(("</details>", ""))
+
+    (year_dir / "index.md").write_text("\n".join(lines))
 
 
 def create_tree(bucket: str, prefix: str, output: Path, cdn_host: str) -> None:
@@ -95,14 +103,18 @@ def create_tree(bucket: str, prefix: str, output: Path, cdn_host: str) -> None:
         ship_name = SHIPS[code]
         ship_dir = root / slug(ship_name)
         ensure_section(ship_dir, ship_name)
-        for date in {d for c, d in groups if c == code}:
-            year_dir = ship_dir / f"{date:%Y}"
-            ensure_section(year_dir, str(date.year))
-            month_dir = year_dir / f"{date:%m}"
-            ensure_section(month_dir, date.strftime("%B"))
+        for year in {d.year for c, d in groups if c == code}:
+            year_dir = ship_dir / f"{year}"
+            ensure_section(year_dir, str(year))
 
+    year_groups: dict[tuple[str, int], dict[dt.date, list[str]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
     for (code, date), keys in groups.items():
-        write_day_page(output, code, date, sorted(keys), cdn_host)
+        year_groups[code, date.year][date].extend(sorted(keys))
+
+    for (code, year), days in year_groups.items():
+        write_year_page(output, code, year, days, cdn_host)
 
 
 @click.command()

--- a/ninox/s3_hugo.py
+++ b/ninox/s3_hugo.py
@@ -80,7 +80,7 @@ def write_year_page(
 
     for month in sorted(month_map):
         month_name = dt.date(year, month, 1).strftime("%B")
-        lines.extend((f"{{{{< details title="{month_name}" >}}}}", ""))
+        lines.extend((f"{{{{< details title=\"{month_name}\" >}}}}", ""))
         for date in sorted(month_map[month]):
             lines.append(f"### {date:%Y-%m-%d}")
             for key in sorted(month_map[month][date]):

--- a/tests/test_s3_hugo.py
+++ b/tests/test_s3_hugo.py
@@ -75,16 +75,23 @@ def test_group_objects(monkeypatch: pytest.MonkeyPatch) -> None:
     }
 
 
-def test_write_day_page(tmp_path: Path) -> None:
-    date = dt.date(2025, 3, 17)
+def test_write_year_page(tmp_path: Path) -> None:
     prefix = "a" * 32
-    key = f"content/ko/menu/abc/{prefix}-file.pdf"
-    s3_hugo.write_day_page(tmp_path, "ko", date, [key], "https://cdn")
-    index = tmp_path / "hal_menus" / "koningsdam" / "2025" / "03" / "17" / "index.md"
+    d1 = dt.date(2025, 3, 17)
+    d2 = dt.date(2025, 4, 1)
+    key1 = f"content/ko/menu/abc/{prefix}-file.pdf"
+    key2 = f"content/ko/menu/def/{prefix}-file2.pdf"
+    s3_hugo.write_year_page(
+        tmp_path, "ko", 2025, {d1: [key1], d2: [key2]}, "https://cdn"
+    )
+    index = tmp_path / "hal_menus" / "koningsdam" / "2025" / "index.md"
     content = index.read_text()
-    assert "title: 2025-03-17" in content
+    assert "title: 2025" in content
     assert "hiddenInHomeList: true" in content
-    assert f"- [file.pdf](https://cdn/{key})" in content
+    assert "<details><summary>March</summary>" in content
+    assert "<details><summary>April</summary>" in content
+    assert f"- [file.pdf](https://cdn/{key1})" in content
+    assert f"- [file2.pdf](https://cdn/{key2})" in content
 
 
 def test_create_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -111,11 +118,8 @@ def test_create_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     year_index = year_dir / "_index.md"
     assert year_index.exists()
     assert "hiddenInHomeList: true" in year_index.read_text()
-    month_dir = year_dir / "03"
-    month_index = month_dir / "_index.md"
-    assert month_index.exists()
-    assert "hiddenInHomeList: true" in month_index.read_text()
-    day_index = month_dir / "17" / "index.md"
-    assert day_index.exists()
-    assert "hiddenInHomeList: true" in day_index.read_text()
-    assert "file.pdf" in day_index.read_text()
+    year_page = year_dir / "index.md"
+    assert year_page.exists()
+    content = year_page.read_text()
+    assert "<details><summary>March</summary>" in content
+    assert "file.pdf" in content


### PR DESCRIPTION
## Summary
- collapse month/day into year pages under hal_menus
- output monthly menu lists as collapsible sections
- update create_tree logic and tests

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .` *(fails: "Cannot find implementation or library stub for module named 'boto3'", etc.)*
- `uv run pytest -q`
- `pre-commit run --files ninox/s3_hugo.py tests/test_s3_hugo.py`