### PR TITLE
Add git commit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Ninox is intended to be a catch-all tool for various LLM scripts I make.
 Currently has the following:
 * `describe-images`: generates alt text for images using OpenAI's Responses API.
 * `generate-menu-tree`: mirrors menu PDFs from S3 into a Hugo content tree.
+* `git commit`: suggests a commit message for staged changes.
 
 ## Requirements
 
@@ -51,3 +52,13 @@ ninox generate-menu-tree --bucket my-bucket --cdn-host https://cdn.example.com
 
 The command creates `content/hal_menus/...` directories with daily `index.md` files linking to the PDFs via the provided CDN host.
 Any leading 32-character MD5 hashes in the filenames are stripped from the link display names.
+
+### git commit
+
+Generate a commit message for staged changes:
+
+```bash
+ninox git commit
+```
+
+Pass `--model` to choose an alternate OpenAI model.

--- a/ninox/git_commands.py
+++ b/ninox/git_commands.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import cast
+
+import click
+from dulwich import porcelain
+from dulwich.repo import Repo
+from openai import OpenAI
+
+from .image_description import load_config
+
+
+@click.group()
+def git() -> None:
+    """Git helper commands."""
+
+
+@git.command()
+@click.option(
+    "--model", default="gpt-4.1-nano", show_default=True, help="OpenAI model to use"
+)
+def commit(model: str) -> None:
+    """Generate a commit message with an LLM and commit staged changes."""
+    repo = Repo(str(Path.cwd()))
+    index_tree = porcelain.write_tree(repo)  # type: ignore[no-untyped-call]
+    try:
+        head_tree = repo[b"HEAD"].tree
+    except KeyError:
+        head_tree = None
+    diff_io = io.BytesIO()
+    porcelain.diff_tree(repo.path, head_tree, index_tree, outstream=diff_io)
+    patch = diff_io.getvalue().decode()
+    if not patch.strip():
+        click.echo("No staged changes to commit.")
+        raise click.Abort
+
+    config = load_config("~/.config/ninox/config.toml")
+    client = OpenAI(api_key=config.tokens.openai.open)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "system",
+                "content": "Write a concise git commit message in the imperative mood.",
+            },
+            {"role": "user", "content": f"Patch:\n{patch}"},
+        ],
+        max_tokens=50,
+    )
+    message = cast("str", response.choices[0].message.content).strip()
+
+    click.echo(f"Suggested commit message:\n{message}")
+    if click.confirm("Edit commit message?", default=False):
+        edited = click.edit(message)
+        if edited is not None:
+            message = edited.strip()
+
+    porcelain.commit(repo.path, message=message)  # type: ignore[no-untyped-call]
+    click.echo("Commit created.")

--- a/ninox/main.py
+++ b/ninox/main.py
@@ -1,6 +1,6 @@
 import click
 
-from ninox import image_description, s3_hugo
+from ninox import git_commands, image_description, s3_hugo
 
 
 @click.group()
@@ -10,3 +10,4 @@ def cli() -> None:
 
 cli.add_command(image_description.describe_images)
 cli.add_command(s3_hugo.generate_menu_tree)
+cli.add_command(git_commands.git)

--- a/tests/test_git_commands.py
+++ b/tests/test_git_commands.py
@@ -1,0 +1,77 @@
+# ruff: noqa: S101
+from pathlib import Path
+
+import click
+import pytest
+from dulwich import porcelain
+from dulwich.repo import Repo
+
+from ninox import git_commands
+
+
+class FakeCompletions:
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def create(self, **_kwargs: object) -> object:
+        return type(
+            "Resp",
+            (),
+            {
+                "choices": [
+                    type(
+                        "C",
+                        (),
+                        {"message": type("M", (), {"content": self._message})()},
+                    )
+                ]
+            },
+        )()
+
+
+class FakeChat:
+    def __init__(self, message: str) -> None:
+        self.completions = FakeCompletions(message)
+
+
+class FakeClient:
+    def __init__(self, *, message: str) -> None:
+        self.chat = FakeChat(message)
+
+
+def make_config() -> object:
+    return type(
+        "Config",
+        (),
+        {
+            "tokens": type(
+                "Tokens", (), {"openai": type("Open", (), {"open": "tok"})()}
+            )()
+        },
+    )()
+
+
+def test_commit_creates_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = porcelain.init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    Path("file.txt").write_text("hello", encoding="utf-8")
+    porcelain.add(repo.path, "file.txt")  # type: ignore[no-untyped-call]
+    porcelain.commit(repo.path, message=b"init")  # type: ignore[no-untyped-call]
+
+    Path("file.txt").write_text("world", encoding="utf-8")
+    porcelain.add(repo.path, "file.txt")  # type: ignore[no-untyped-call]
+
+    monkeypatch.setattr(
+        git_commands, "OpenAI", lambda *_, **__: FakeClient(message="Update file")
+    )
+    monkeypatch.setattr(git_commands, "load_config", lambda _path: make_config())
+    monkeypatch.setattr(click, "confirm", lambda *_a, **_k: False)
+    monkeypatch.setattr(click, "edit", lambda msg: msg)
+
+    callback = git_commands.commit.callback
+    assert callback is not None
+    callback("model")
+
+    repo = Repo(str(tmp_path))
+    last = repo[repo.head()]
+    assert last.message.decode().strip() == "Update file"


### PR DESCRIPTION
## Summary
- add new CLI group `git` with a `commit` command
- allow editing the generated commit message
- document the new command in the README
- test commit helper logic

## Testing
- `uv run ruff check ninox tests`
- `uv run mypy ninox tests`
- `uv run pytest -q`
- `pre-commit run --files ninox/git_commands.py ninox/main.py README.md tests/test_git_commands.py`
