### PR TITLE
Add default editor and dry-run for git commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,7 @@ Generate a commit message for staged changes:
 ninox git commit
 ```
 
+The suggested message opens in your `$EDITOR` for tweaks.
+
 Pass `--model` to choose an alternate OpenAI model.
+Use `--dry-run` to print the suggestion without committing.


### PR DESCRIPTION
## Summary
- always open editor when generating commit message
- support `--dry-run` option to only show suggested commit message
- update README instructions
- adjust tests for new workflow
- add new test for dry-run behavior

## Testing
- `uv run ruff format ninox/git_commands.py tests/test_git_commands.py`
- `uv run ruff check ninox/git_commands.py tests/test_git_commands.py`
- `uv run mypy ninox/git_commands.py tests/test_git_commands.py`
- `uv run pytest -q`
- `pre-commit run --files ninox/git_commands.py tests/test_git_commands.py README.md`
