### PR TITLE
Refactor config handling

### DIFF
--- a/ninox/image_description.py
+++ b/ninox/image_description.py
@@ -5,6 +5,7 @@ import json
 import mimetypes
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from openai import OpenAI
@@ -12,7 +13,8 @@ from openai.types.responses import ResponseInputImageParam, ResponseInputTextPar
 from openai.types.responses.response_input_param import Message
 from PIL import Image
 
-from .config import load_config
+if TYPE_CHECKING:
+    from .config import Config
 
 
 def get_image_description(
@@ -124,7 +126,10 @@ def process_directory(client: OpenAI, directory: Path, context: str) -> None:
 @click.command()
 @click.argument("directory", type=Path)
 @click.option("--context", "-c", help="Context for this batch of images")
-def describe_images(directory: Path, context: str | None = None) -> None:
+@click.pass_obj
+def describe_images(
+    config: Config, directory: Path, context: str | None = None
+) -> None:
     if not directory.is_dir():
         print(f"{directory} is not a directory")
         return
@@ -137,8 +142,7 @@ def describe_images(directory: Path, context: str | None = None) -> None:
             print("No context provided; exiting.")
             return
 
-    # Load configuration and initialize OpenAI client
-    config = load_config("~/.config/ninox/config.toml")
+    # Initialize OpenAI client using passed configuration
     api_key = config.tokens.openai.open
     client = OpenAI(api_key=api_key)
 

--- a/ninox/main.py
+++ b/ninox/main.py
@@ -1,11 +1,14 @@
 import click
 
 from ninox import git_commands, image_description, s3_hugo
+from ninox.config import load_config
 
 
 @click.group()
-def cli() -> None:
-    pass
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Base command group that loads configuration."""
+    ctx.obj = load_config("~/.config/ninox/config.toml")
 
 
 cli.add_command(image_description.describe_images)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+# ruff: noqa: S101
+import click
+import pytest
+from click.testing import CliRunner
+
+from ninox import main
+
+
+def test_cli_loads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_load_config(path: str) -> dict[str, str]:
+        captured["path"] = path
+        return {"token": "x"}
+
+    monkeypatch.setattr(main, "load_config", fake_load_config)
+
+    @click.command()
+    @click.pass_obj
+    def dummy(obj: object) -> None:
+        captured["obj"] = obj
+
+    main.cli.add_command(dummy)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(main.cli, ["dummy"])
+        assert result.exit_code == 0
+    finally:
+        main.cli.commands.pop("dummy", None)
+
+    assert captured["path"] == "~/.config/ninox/config.toml"
+    assert captured["obj"] == {"token": "x"}


### PR DESCRIPTION
## Summary
- load config once in `cli` group and pass via context
- update `commit` and `describe-images` to use passed config
- add tests for new CLI behaviour and adjust existing tests

## Testing
- `uv run ruff check ninox tests`
- `uv run mypy ninox tests`
- `uv run pytest -q`
- `pre-commit run --files ninox/main.py ninox/git_commands.py ninox/image_description.py tests/test_git_commands.py tests/test_main.py`